### PR TITLE
CIRCLE 13537 Xenial Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 :wave:, this repository contains the scripts required to install a copy of
 CircleCI Server on non-AWS environments.
-It is currently still only tested on Ubuntu 14.04, although 16.04 should also work.
+It is currently tested on Ubuntu 14.04 and 16.04.
 
 If you are looking to install Server on a cloud provider, or require the ability to launch remote_docker or machine builds, you should look at [enterprise-setup](https://github.com/circleci/enterprise-setup).
 

--- a/provision-nomad-client-ubuntu.sh
+++ b/provision-nomad-client-ubuntu.sh
@@ -123,3 +123,4 @@ echo "--------------------------------------"
 echo "      Starting Nomad service"
 echo "--------------------------------------"
 service nomad restart
+is_xenial && systemctl enable nomad


### PR DESCRIPTION
Xenial has different requirements for installation
* [meta packages](https://help.ubuntu.com/community/MetaPackages) are used for kernel
* `eth0` is replaced by `ens3`
* adds systemd unit for nomad