### PR TITLE
Remove ubuntu 16 from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 :wave:, this repository contains the scripts required to install a copy of
 CircleCI Server on non-AWS environments.
-It is currently still only tested on Ubuntu 14.04, although 16.04 should also work.
+It is currently still only tested on Ubuntu 14.04.
 
 If you are looking to install Server on a cloud provider, or require the ability to launch remote_docker or machine builds, you should look at [enterprise-setup](https://github.com/circleci/enterprise-setup).
 


### PR DESCRIPTION
SAP used this and installed on 16.04, but it does not work, several errors.  Using 14.04 worked fine.