### PR TITLE
[CIRCLE-14461] nomad: Guard against non-zero exit on !is_xenial

### DIFF
--- a/provision-nomad-client-ubuntu.sh
+++ b/provision-nomad-client-ubuntu.sh
@@ -145,4 +145,6 @@ echo "--------------------------------------"
 echo "      Starting Nomad service"
 echo "--------------------------------------"
 service nomad restart
-is_xenial && systemctl enable nomad
+if is_xenial; then
+  systemctl enable nomad
+fi


### PR DESCRIPTION
If `is_xenial` is false then the return code of this script will be 1
which causes the static install tests in circleci/server-manifest (after
they were updated to use upstream in circleci/server-manifest@2c86dcd)
to fail. Guard against this by wrapping it in an `if` condition which
always returns 0.