### PR TITLE
CIRCLE-16271 apply patch for CVE 2019-5736

### DIFF
--- a/provision-nomad-client-ubuntu.sh
+++ b/provision-nomad-client-ubuntu.sh
@@ -80,6 +80,12 @@ else
 fi
 apt-get -y install docker-ce=$(docker_package_name)
 
+# force docker to use userns-remap to mitigate CVE 2019-5736
+apt-get -y install jq
+tmp=$(mktemp)
+cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
+jq '."userns-remap": "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
+
 echo "--------------------------------------"
 echo "         Installing nomad"
 echo "--------------------------------------"

--- a/provision-nomad-client-ubuntu.sh
+++ b/provision-nomad-client-ubuntu.sh
@@ -84,7 +84,7 @@ apt-get -y install docker-ce=$(docker_package_name)
 apt-get -y install jq
 tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
-jq '."userns-remap": "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
+jq '."userns-remap"= "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
 
 echo "--------------------------------------"
 echo "         Installing nomad"


### PR DESCRIPTION
Adjust the cloud init script that installs Docker for CVE 2019-5736

This change uses jq to add a single entry to the installed docker config file

Doesn't assume the presence of jq
Saves the original file to /etc/docker/daemon.json.orig
Assumes:
* the path for the docker config is /etc/docker/daemon.json
* we are able to write to the above file