### PR TITLE
install docker-ce-cli which has same version of docker-ce

### DIFF
--- a/provision-nomad-client-ubuntu.sh
+++ b/provision-nomad-client-ubuntu.sh
@@ -91,7 +91,9 @@ else
   apt-get install -y "linux-image-extra-$(uname -r)" linux-image-extra-virtual
   apt-get -y install cgmanager
 fi
-apt-get -y install docker-ce=$(docker_package_name)
+
+docker_pkg=$(docker_package_name)
+apt-get -y install docker-ce=${docker_pkg} docker-ce-cli=${docker_pkg}
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq


### PR DESCRIPTION
`docker-ce` package depends on `docker-ce-cli` so `apt-get` installs `docker-ce-cli` automatically but it is the newest version.
The newest `docker-ce-cli` does not support `docker-ce` version 18.x so need to install specific version, same version of `docker-ce`

## Reference

* https://docs.docker.com/engine/install/debian/#install-docker-engine