### PR TITLE
Add restart docker step

### DIFF
--- a/provision-nomad-client-ubuntu.sh
+++ b/provision-nomad-client-ubuntu.sh
@@ -100,6 +100,7 @@ mkdir -p /etc/docker
 tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
 jq '."userns-remap"= "default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
+service docker restart
 
 echo "--------------------------------------"
 echo "         Installing nomad"


### PR DESCRIPTION
To apply `deamon.json` configuration, it needs to restart docker service. The current `deamon.json` change the namespace to `dockremap` (default). However, the current config doesn't restart docker, so`ci-privileged` of the docker network is created by the `root` namespace.

So when nomad client restarts, it makes changing the namespace to `dockremap`, so that docker network would be missing.

> https://docs.docker.com/engine/security/userns-remap/

